### PR TITLE
Add position for database field

### DIFF
--- a/src/metabase/driver/dynamodb/query_processor.clj
+++ b/src/metabase/driver/dynamodb/query_processor.clj
@@ -23,10 +23,11 @@
   (let [table-desc (-> (.describeTable *dynamodb-client* table)
                        (.getTable))]
     (println "describe-table" table-desc)
-    (for [attribute-def (.getAttributeDefinitions table-desc)]
+    (for [attribute-def (.getAttributeDefinitions table-desc) idx]
       {:name      (.getAttributeName attribute-def)
        :database-type (.getAttributeType attribute-def)
-       :base-type (dynamodb-type->base-type (.getAttributeType attribute-def))})) )
+       :base-type (dynamodb-type->base-type (.getAttributeType attribute-def))
+       :database-position idx})) )
 
 (defmulti ^:private ->rvalue
   "Format this `Field` or value for use as the right hand value of an expression, e.g. by adding `$` to a `Field`'s


### PR DESCRIPTION
Error:
When trying to sync Table schema for dynamo events table, we see the error below
Caused by: org.postgresql.util.PSQLException: ERROR: null value in column "position" of relation "metabase_field" violates not-null constraint

Upon examining, seems like postgres db of metabase expects a position field to be populated, I just used mongo plugin as example