### PR TITLE
Add database-position for a field

### DIFF
--- a/src/metabase/driver/dynamodb/query_processor.clj
+++ b/src/metabase/driver/dynamodb/query_processor.clj
@@ -23,10 +23,11 @@
   (let [table-desc (-> (.describeTable *dynamodb-client* table)
                        (.getTable))]
     (println "describe-table" table-desc)
-    (for [attribute-def (.getAttributeDefinitions table-desc)]
+    (for [[idx attribute-def (.getAttributeDefinitions table-desc)] (map-indexed vector (.getAttributeDefinitions table-desc))]
       {:name      (.getAttributeName attribute-def)
        :database-type (.getAttributeType attribute-def)
-       :base-type (dynamodb-type->base-type (.getAttributeType attribute-def))})) )
+       :base-type (dynamodb-type->base-type (.getAttributeType attribute-def))
+       :database-position idx})) )
 
 (defmulti ^:private ->rvalue
   "Format this `Field` or value for use as the right hand value of an expression, e.g. by adding `$` to a `Field`'s


### PR DESCRIPTION
Error:
When trying to sync Table schema for dynamo events table, we see the error below
Caused by: org.postgresql.util.PSQLException: ERROR: null value in column "position" of relation "metabase_field" violates not-null constraint

Mongo plugin setting the position here - https://github.com/metabase/metabase/blob/master/modules/drivers/mongo/src/metabase/driver/mongo.clj#L173

The describe-table returns a table metadata that has an array of fields, for each field metabase checks if it is assigned a database-position, the PR adds a database position to the returned fields set

Check the table metadata here with the fields array - https://github.com/metabase/metabase/blob/v0.48.6/src/metabase/sync/interface.clj#L56

Proof that the for loop works was done by creating a small snippet of code  (which exactly matches the change in the PR) in clojure playground and making sure it runs


<img width="533" alt="Screen Shot 2024-03-15 at 10 55 48 am" src="https://github.com/GorillaStack/metabase-dynamodb-driver/assets/107895368/6e21a33b-b933-4407-882a-7b8113f36b93">

