### PR TITLE
fix row values in wrong columns. Add pagination to query. ab#221712

### DIFF
--- a/src/metabase/driver/dynamodb/query_processor.clj
+++ b/src/metabase/driver/dynamodb/query_processor.clj
@@ -147,27 +147,3 @@
     (respond
       {:cols (map (fn [key] {:name (name key)}) first-item-keys)}
       (map (fn [item] (map (fn [k] (get (get item :data) k)) first-item-keys)) parsed-items))))
-
-;; (defn execute-reducible-query
-;;   [{{:keys [collection query mbql? projections]} :native} context respond]
-;;   (dynamodb.util/log "execute-reducible-query:"  query)
-;;   (dynamodb.util/log "collection:" collection)
-;;   (let [parsed-query (json/parse-string query)
-;;     table-name (get parsed-query "TableName")
-;;     index (get parsed-query "Index")
-;;     key-condition-expression (get parsed-query "KeyConditionExpression")
-;;     query-req (QueryRequest.)]
-;;     (doto query-req
-;;       (.setTableName table-name)
-;;       (.setIndexName index)
-;;       (.setKeyConditionExpression key-condition-expression)
-;;       (.setExpressionAttributeValues (get parsed-query "ExpressionAttributeValues"))
-;;       (.setExpressionAttributeNames (get parsed-query "ExpressionAttributeNames")))
-;;     (dynamodb.util/log "query-req:" query-req)
-;;     (let [items (-> (.query *dynamodb-client* query-req) (.getItems))
-;;           parsed-items (mapv far/db-item->clj-item items)
-;;           first-item (first parsed-items)
-;;           first-item-keys (keys (get first-item :data))]
-;;       (respond
-;;         {:cols (map (fn [key] {:name (name key)}) first-item-keys)}
-;;         (map (fn [item] (map (fn [k] (get (get item :data) k)) first-item-keys)) parsed-items)))))

--- a/src/metabase/driver/dynamodb/query_processor.clj
+++ b/src/metabase/driver/dynamodb/query_processor.clj
@@ -17,10 +17,12 @@
 
 (def ^:dynamic ^:private *query* nil)
 
+;; Function to list all tables in the DynamoDB client
 (defn list-tables []
   (-> (.listTables *dynamodb-client*)
       (.getTableNames)))
 
+;; Function to map DynamoDB attribute types to base types
 (defn- dynamodb-type->base-type [attr-type]
   (case attr-type
     "M"      :type/*
@@ -33,6 +35,7 @@
     "NULL"   :type/Nil
     :type/*))
 
+;; Function to describe a table, including its attributes and their types
 (defn describe-table [table]
   (let [table-desc (-> (.describeTable *dynamodb-client* table)
                        (.getTable))]
@@ -59,12 +62,14 @@
   {:arglists '([field])}
   mbql.u/dispatch-by-clause-name-or-class)
 
+;; Function to get the components of a field name, including its parent if it has one
 (defn- field-name-components [{:keys [parent-id], field-name :name, :as _field}]
   (concat
    (when parent-id
      (field-name-components (lib.metadata/field (qp.store/metadata-provider) parent-id)))
    [field-name]))
 
+;; Function to return a single string name for a field, creating a combined qualified name for nested fields
 (mu/defn field->name
   "Return a single string name for `field`. For nested fields, this creates a combined qualified name."
   ([field]
@@ -74,22 +79,28 @@
     separator :- [:or :string char?]]
    (str/join separator (field-name-components field))))
 
+;; Method to return the input as is for the default case
 (defmethod ->rvalue :default
   [x]
   x)
 
+;; Method to return the name of a model/Field
 (defmethod ->lvalue :model/Field
   [field]
   (field->name field))
 
+;; Method to return the lvalue of a field
 (defmethod ->lvalue :field
   [[_ id-or-name]]
   (->lvalue (qp.store/field id-or-name)))
 
+;; Method to return the rvalue of a field
 (defmethod ->rvalue :field
   [[_ id-or-name]]
   (->rvalue (qp.store/field id-or-name)))
 
+;; Function to handle fields in a pipeline context, updating projections and the query
+;; This function requires updating to get GUI queries to work
 (defn- handle-fields [{:keys [fields]} pipeline-ctx]
   (dynamodb.util/log "handle-fields" fields)
   (if-not (seq fields)
@@ -100,6 +111,8 @@
           (assoc :projections (map (comp keyword first) new-projections))
           (update :query conj (into {} new-projections))))))
 
+;; Function to convert MBQL to native query format
+;; This function requires updating to get GUI queries to work
 (defn mbql->native [{{source-table-id :source-table} :query, :as query}]
   (let [{source-table-name :name} (qp.store/table source-table-id)]
     (binding [*query* query]
@@ -112,7 +125,9 @@
        :collection  nil
        :mbql?       true})))
 
+;; Function to execute a query on DynamoDB and return the results
 (defn execute-query [parsed-query dynamodb-client]
+  ;; Create a QueryRequest object and set its attributes
   (let [query-req (QueryRequest.)]
     (doto query-req
       (.setTableName (get parsed-query "TableName"))
@@ -120,18 +135,23 @@
       (.setKeyConditionExpression (get parsed-query "KeyConditionExpression"))
       (.setExpressionAttributeValues (get parsed-query "ExpressionAttributeValues"))
       (.setExpressionAttributeNames (get parsed-query "ExpressionAttributeNames")))
+    ;; Create a loop to handle paginated results
     (loop [results [] last-key nil]
+      ;; Query the DynamoDB client and get the items, if last-key is not nil, use it as the ExclusiveStartKey
       (let [response (.query dynamodb-client (if last-key
                                                (.withExclusiveStartKey query-req last-key)
                                                query-req))]
+        ;; Parse the items and get the last key. far/db-item->clj-item is a function to convert DynamoDB items to Clojure maps
         (let [items (-> response .getItems)
               parsed-items (mapv far/db-item->clj-item items)
               new-results (concat results parsed-items)
               next-key (.getLastEvaluatedKey response)]
+          ;; If there is a next key, recur (continue loop) with the new results and the next key, otherwise return the results
           (if next-key
             (recur new-results next-key)
             new-results))))))
 
+;; Function to execute a reducible query and respond with the results
 (defn execute-reducible-query
   [{{:keys [collection query mbql? projections]} :native} context respond]
   (dynamodb.util/log "execute-reducible-query:"  query)
@@ -142,5 +162,7 @@
         first-item-keys (keys (get first-item :data))]
     (dynamodb.util/log "first-item:" first-item)
     (respond
+      ;; Create a map of the key names from the first item
       {:cols (map (fn [key] {:name (name key)}) first-item-keys)}
+      ;; Map the data from each item to a list of lists, where each list is a row of data matching the order of the columns
       (map (fn [item] (map (fn [k] (get (get item :data) k)) first-item-keys)) parsed-items))))

--- a/src/metabase/driver/dynamodb/query_processor.clj
+++ b/src/metabase/driver/dynamodb/query_processor.clj
@@ -113,14 +113,11 @@
        :mbql?       true})))
 
 (defn execute-query [parsed-query dynamodb-client]
-  (let [table-name (get parsed-query "TableName")
-        index (get parsed-query "Index")
-        key-condition-expression (get parsed-query "KeyConditionExpression")
-        query-req (QueryRequest.)]
+  (let [query-req (QueryRequest.)]
     (doto query-req
-      (.setTableName table-name)
-      (.setIndexName index)
-      (.setKeyConditionExpression key-condition-expression)
+      (.setTableName (get parsed-query "TableName"))
+      (.setIndexName (get parsed-query "Index"))
+      (.setKeyConditionExpression (get parsed-query "KeyConditionExpression"))
       (.setExpressionAttributeValues (get parsed-query "ExpressionAttributeValues"))
       (.setExpressionAttributeNames (get parsed-query "ExpressionAttributeNames")))
     (loop [results [] last-key nil]


### PR DESCRIPTION
Didn't see this bug until testing queries in prod, but some results were putting values into the incorrect column as the old implementation was based on the order of key-value pairs in each item, which is not guaranteed to be consistant.

This PR fixes that issue and also implements pagination for queries.